### PR TITLE
refactor: use native http server

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,18 @@ const fs = require('fs');
 const typescript = require('typescript');
 const babel = require('@babel/core');
 const co = require('./functions.js');
-const fastify = require('fastify')();
-fastify.get('/', (req, res) => res.send('OK'));
-fastify.listen(3000, '0.0.0.0', () => console.log('website is alive'));
+
+{
+  const { createServer } = require('http');
+
+  const server = createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('OK');
+  });
+
+  server.listen(3000, () => console.log('website is alive'));
+}
+
 // eslint-disable-next-line no-shadow-restricted-names
 const eval = global.eval;
 const ___ = {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@discordjs/voice": "^0.7.5",
     "command-tags": "^1.1.6",
     "discord.js": "^13.1.0",
-    "fastify": "^3.27.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "skia-canvas": "^0.9.25",


### PR DESCRIPTION
The builtin `http` module is faster than fastify (startup times too, cause less deps), and you're not really using any of the features that give fastify the advantage.