### PR TITLE
fix: correct syntax highlighting in long outputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -404,7 +404,7 @@ client.on('messageCreate', async (message) => {
             .setDescription(`**Executed in ${time}.**`)
             .addField(
               'Input',
-              `\`\`\`${tags.matches.ts ? 'ts' : 'js'}\n${toEval.replace(
+              `\`\`\`ts\n${toEval.replace(
                 /```/g,
                 '``\u200b`‎'
               )}\n\`\`\``
@@ -422,11 +422,11 @@ client.on('messageCreate', async (message) => {
             .setAuthor('Eval')
             .setTitle('Output')
             .setDescription(
-              `\`\`\`js\n${res.replace(/```/g, '``\u200b`')}\n\`\`\``
+              `\`\`\`${tags.matches['no-ansi'] ? 'js' : 'ansi'}\n${res.replace(/```/g, '``\u200b`')}\n\`\`\``
             )
             .addField(
               'Input',
-              `\`\`\`${tags.matches.ts ? 'ts' : 'js'}\n${
+              `\`\`\`ts\n${
                 toEval.replace(/```/g, '``\u200b`') || '\u200b'
               }\n\`\`\``
             )


### PR DESCRIPTION
Fixes the bug where when the output is too long the syntax highlighting gets messed up.
![image](https://user-images.githubusercontent.com/75394401/151634451-8d95ab26-3f0d-48c1-9d92-25f78e5abd35.png)
